### PR TITLE
Always inline trivial forwarder methods

### DIFF
--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -1351,6 +1351,10 @@ bool ciMethod::is_unboxing_method() const {
   return false;
 }
 
+bool ciMethod::is_tiny_inline () {
+  return get_flow_analysis()->is_tiny_inline();
+}
+
 BCEscapeAnalyzer  *ciMethod::get_bcea() {
 #ifdef COMPILER2
   if (_bcea == NULL) {

--- a/src/hotspot/share/ci/ciMethod.hpp
+++ b/src/hotspot/share/ci/ciMethod.hpp
@@ -356,6 +356,7 @@ class ciMethod : public ciMetadata {
   bool is_boxing_method() const;
   bool is_unboxing_method() const;
   bool is_object_initializer() const;
+  bool is_tiny_inline();
 
   bool can_be_statically_bound(ciInstanceKlass* context) const;
 

--- a/src/hotspot/share/ci/ciTypeFlow.hpp
+++ b/src/hotspot/share/ci/ciTypeFlow.hpp
@@ -44,6 +44,8 @@ private:
   int _max_stack;
   int _code_size;
   bool      _has_irreducible_entry;
+  int       _invoke_count;
+  bool      _is_tiny_inline;
 
   const char* _failure_reason;
 
@@ -67,6 +69,7 @@ public:
   int       max_cells() const  { return _max_locals + _max_stack; }
   int       code_size() const  { return _code_size; }
   bool      has_irreducible_entry() const { return _has_irreducible_entry; }
+  bool      is_tiny_inline() const { return _is_tiny_inline; }
 
   // Represents information about an "active" jsr call.  This
   // class represents a call to the routine at some entry address

--- a/src/hotspot/share/interpreter/bytecodes.hpp
+++ b/src/hotspot/share/interpreter/bytecodes.hpp
@@ -411,6 +411,7 @@ class Bytecodes: AllStatic {
   static bool        is_java_code   (Code code)    { return 0 <= code && code < number_of_java_codes; }
 
   static bool        is_store_into_local(Code code){ return (_istore <= code && code <= _astore_3); }
+  static bool        is_load_from_local(Code code) { return (_iload <= code && code <= _aload_3); }
   static bool        is_const       (Code code)    { return (_aconst_null <= code && code <= _ldc2_w); }
   static bool        is_zero_const  (Code code)    { return (code == _aconst_null || code == _iconst_0
                                                            || code == _fconst_0 || code == _dconst_0); }

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -630,7 +630,6 @@ bool Method::is_vanilla_constructor() const {
   return true;
 }
 
-
 bool Method::compute_has_loops_flag() {
   BytecodeStream bcs(methodHandle(Thread::current(), this));
   Bytecodes::Code bc;

--- a/src/hotspot/share/opto/bytecodeInfo.cpp
+++ b/src/hotspot/share/opto/bytecodeInfo.cpp
@@ -388,6 +388,11 @@ bool InlineTree::try_to_inline(ciMethod* callee_method, ciMethod* caller_method,
     return true;
   }
 
+  if (InlineAccessors && callee_method->is_tiny_inline()) {
+    set_msg("tiny when inlined");
+    return true;
+  }
+
   // suppress a few checks for accessors and trivial methods
   if (callee_method->code_size() > MaxTrivialSize) {
 

--- a/test/hotspot/jtreg/compiler/inlining/InlineForwarders.java
+++ b/test/hotspot/jtreg/compiler/inlining/InlineForwarders.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary ciMethod::is_tiny_inline should cover forwarder methods
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ *
+ * @run driver compiler.inlining.InlineForwarders
+ */
+
+package compiler.inlining;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class InlineForwarders {
+    public static void main(String[] args) throws Exception {
+        // try some sanity checks first
+        doTest();
+
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-XX:+IgnoreUnrecognizedVMOptions", "-showversion",
+                "-server", "-XX:-TieredCompilation", "-Xbatch",
+                "-XX:+PrintCompilation", "-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintInlining",
+                "-XX:CompileCommand=dontinline,compiler.inlining.InlineForwarders::underlying*",
+                "-XX:CompileCommand=dontinline,compiler.inlining.InlineForwarders::doTest*",
+                "-XX:MaxInlineLevel=0",
+                Launcher.class.getName());
+
+        OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
+
+        analyzer.shouldHaveExitValue(0);
+        // The test is applicable only to C2 (present in Server VM).
+        if (analyzer.getStderr().contains("Server VM")) {
+            analyzer.shouldMatch("InlineForwarders::forward1 \\(\\d+ bytes\\)   tiny when inlined");
+            analyzer.shouldMatch("InlineForwarders::forward2a \\(\\d+ bytes\\)   tiny when inlined");
+            analyzer.shouldNotMatch("InlineForwarders::forwardNok3 \\(\\d+ bytes\\)   tiny when inlined");
+        }
+    }
+
+    public void underlying() { toString().hashCode(); }
+    public void underlying(int a) { toString().hashCode(); }
+    public void forward1()   { underlying(); }
+    public void forward2a()   { underlying(); }
+    public void forward2b()   { forward2a(); }
+    public void forwardNok3()   { underlying(); underlying(); }
+
+    static void doTest() {
+        InlineForwarders o = new InlineForwarders();
+        o.forward1();
+        o.forward2b();
+        o.forwardNok3();
+    }
+
+    static class Launcher {
+        public static void main(String[] args) throws Exception {
+            for (int c = 0; c < 20_000; c++) {
+              doTest();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Does not contribute to the MaxInlineLevel budget.

Protoyping the changes to HotSpot inlining policy discussed on [hotspot-compiler-dev](https://mail.openjdk.java.net/pipermail/hotspot-compiler-dev/2019-December/036501.html).

Related:

 - [JDK-8056071](https://bugs.openjdk.java.net/browse/JDK-8056071) introduced a [special case for constant getter bytecode](https://github.com/openjdk/jdk/commit/00aa20db4a29174d4fa530b7d02dbee6a1af705a#diff-5493ff9ffe7cc9c72c8f01c85b0f0cf3R58) shapes (e.g. `int foo() { return 42 }`. I think the intention of that change was to make a test case stable?